### PR TITLE
Add [robot] extras for requiring dependencies for Robot Framework tests

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 4.2.2 (unreleased)
 ------------------
 
+- Add [robot] extras for requiring dependnecies for Robot Framework
+  tests with Selenium2Library
+  [datakurre]
 - Install PythonScripts as zope product 
   [mikejmets]
 

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,11 @@ tests_require = ['Products.CMFCore',
                  'zope.publisher',
                  ]
 
+robot_require = ['robotsuite',
+                 'robotframework-selenium2library',
+                 'decorator',
+                 'selenium']
+
 setup(name='plone.app.testing',
       version=version,
       description="Testing tools for Plone-the-application, based on plone.testing.",
@@ -52,5 +57,6 @@ setup(name='plone.app.testing',
       tests_require=tests_require,
       extras_require={
         'test': tests_require,
+        'robot': robot_require,
       },
       )


### PR DESCRIPTION
@tisto, @esteele, @emanlove 

This is the testing sprint pull request for adding [robot] extras for plone.app.testing to make it easy to require all dependencies for writing and running functional Selenium tests in Robot Framework syntax.

We require
- `robotsuite`, which is a Collective package for wrapping Robot Framework test suite into Python unittest testsuites (and make them support plone.app.testing layers)
- `robotframework-selenium2library` for the Selenium 2 / Webdriver keywords for Robot Framework
- `selenium` and `decorator` are dependencies of `robotframework`, but we'd like to require them explicitly, because for some reasons they are not fetched in all environments (e.g. they are with Python 2.7 and distribute, but maybe not with Python 2.6 and setuptools).

Both `robotsuite` and `robotframework-selenium2library` require `robotframework` package. Because we don't import anything from it, we shouldn't need to require it explicitly.
