### PR TITLE
Create a MockMailHostLayer layer

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,9 @@ Changelog
 
 New:
 
-- *add item here*
+- Add a MOCK_MAILHOST_FIXTURE fixture that integration and functional tests layers can depend on.
+  This allows to easily check how mails are sent from Plone.
+  [gforcada]
 
 Fixes:
 

--- a/docs/source/README.rst
+++ b/docs/source/README.rst
@@ -144,6 +144,40 @@ lifecycle or transaction management. Instead, you should use a layer
 created with either the ``IntegrationTesting`` or ``FunctionalTesting``
 classes, as outlined below.
 
+Mock MailHost
+-------------
+
++------------+--------------------------------------------------+
+| Layer:     | ``plone.app.testing.MOCK_MAILHOST_FIXTURE``      |
++------------+--------------------------------------------------+
+| Class:     | ``plone.app.testing.layers.MockMailHostLayer``   |
++------------+--------------------------------------------------+
+| Bases:     | ``plone.app.testing.layers.PLONE_FIXTURE``       |
++------------+--------------------------------------------------+
+| Resources: |                                                  |
++------------+--------------------------------------------------+
+
+This layer builds on top of ``PLONE_FIXTURE`` to patch Plone's MailHost implementation.
+
+With it,
+any attempt to send an email will instead store each of them as a string in a list in ``portal.MailHost.messages``.
+
+You should not use this layer directly, as it does not provide any test
+lifecycle or transaction management. Instead, you should use a layer
+created with either the ``IntegrationTesting`` or ``FunctionalTesting``
+classes, like::
+
+    from plone.app.testing import MOCK_MAILHOST_FIXTURE
+
+    MY_INTEGRATION_TESTING = IntegrationTesting(
+        bases=(
+            MY_FIXTURE,
+            MOCK_MAILHOST_FIXTURE,
+        ),
+        name="MyFixture:Integration"
+    )
+
+
 PloneWithPackageLayer class
 ---------------------------
 

--- a/plone/app/testing/__init__.py
+++ b/plone/app/testing/__init__.py
@@ -28,6 +28,7 @@ from plone.app.testing.interfaces import TEST_USER_PASSWORD
 from plone.app.testing.interfaces import TEST_USER_ROLES
 from plone.app.testing.layers import FunctionalTesting
 from plone.app.testing.layers import IntegrationTesting
+from plone.app.testing.layers import MOCK_MAILHOST_FIXTURE
 from plone.app.testing.layers import PLONE_FIXTURE
 from plone.app.testing.layers import PLONE_FTP_SERVER
 from plone.app.testing.layers import PLONE_FUNCTIONAL_TESTING

--- a/plone/app/testing/utils.py
+++ b/plone/app/testing/utils.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+from persistent.list import PersistentList
+from Products.MailHost.MailHost import _mungeHeaders
+from Products.MailHost.MailHost import MailBase
+
+
+class MockMailHost(MailBase):
+    """A MailHost that collects messages instead of sending them.
+    """
+
+    def __init__(self, id):
+        self.reset()
+
+    def reset(self):
+        self.messages = PersistentList()
+
+    def _send(self, mfrom, mto, messageText, immediate=False):
+        """ Send the message """
+        self.messages.append(messageText)
+
+    def send(self, messageText, mto=None, mfrom=None, subject=None,
+             encode=None, immediate=False, charset=None, msg_type=None):
+        messageText, mto, mfrom = _mungeHeaders(messageText,
+                                                mto, mfrom, subject,
+                                                charset=charset,
+                                                msg_type=msg_type)
+        self.messages.append(messageText)


### PR DESCRIPTION
This makes it easier to third party packages to test mail functionality.

Fixes: https://github.com/plone/plone.app.testing/issues/19

Question: should we add this fixture to the integration and functional testing layers? i.e. to ``PLONE_INTEGRATION_TESTING``, ``PLONE_FUNCTIONAL_TESTING``, ``PLONE_ZSERVER`` and ``PLONE_FTP_SERVER`` ?

I copied ``Products.CMFPlone.tests.utils.MockMailHost`` into here so that plone.app.testing does not depend on it (and the point of having it on CMFPlone becomes moot as soon as we have it here). A deprecation warning should be added in CMFPlone and later on removed.