### PR TITLE
Make sure ramcache object is valid

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,10 @@ Fixes:
 - Cleanup code, flake8, sort imports, etc.
   [gforcada]
 
+- Fix RAM cache error with bbb.PloneTestCase.
+  [ebrehault]
+
+
 5.0b6 (2015-08-22)
 ------------------
 

--- a/plone/app/testing/layers.py
+++ b/plone/app/testing/layers.py
@@ -308,7 +308,7 @@ class PloneTestLifecycle(object):
         from zope.component import queryUtility
         from plone.memoize.ram import IRAMCache
         cache = queryUtility(IRAMCache)
-        if cache is not None:
+        if cache and getattr(cache, '_cacheId', None):
             cache.invalidateAll()
 
         # Unset the local component site


### PR DESCRIPTION
During bbb.PloneTestCase tear down, we might get an empty RAM cache object (I haven't been able to identify how...), so we need to check if the object is valid before calling `invalidateAll`.