### PR TITLE
Use get_installer and make profile upgrade versions persistent

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,9 @@ Breaking changes:
 
 New features:
 
+- Use get_installer instead of portal_quickinstaller when available, for
+  Plone 5.1 and higher.  [maurits]
+
 - In PloneSandboxLayer make profile upgrade versions persistent.  This
   way installed profile versions get reset in teardown.  [maurits]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,8 @@ Breaking changes:
 
 New features:
 
-- *add item here*
+- In PloneSandboxLayer make profile upgrade versions persistent.  This
+  way installed profile versions get reset in teardown.  [maurits]
 
 Bug fixes:
 

--- a/plone/app/testing/helpers.py
+++ b/plone/app/testing/helpers.py
@@ -84,13 +84,27 @@ def quickInstallProduct(portal, productName, reinstall=False):
     z2.login(app['acl_users'], SITE_OWNER_NAME)
 
     try:
-        quickinstaller = portal['portal_quickinstaller']
+        from Products.CMFPlone.utils import get_installer
+    except ImportError:
+        # BBB For Plone 5.0 and lower.
+        qi = portal['portal_quickinstaller']
+        old_qi = True
+    else:
+        qi = get_installer(portal)
+        old_qi = False
 
-        if quickinstaller.isProductInstalled(productName):
-            if reinstall:
-                quickinstaller.reinstallProducts([productName])
+    try:
+        if old_qi:
+            if not qi.isProductInstalled(productName):
+                qi.installProduct(productName)
+            elif reinstall:
+                qi.reinstallProducts([productName])
         else:
-            quickinstaller.installProduct(productName)
+            if not qi.is_product_installed(productName):
+                qi.install_product(productName, allow_hidden=True)
+            elif reinstall:
+                qi.uninstall_product(productName)
+                qi.install_product(productName, allow_hidden=True)
 
         portal.clearCurrentSkin()
         portal.setupCurrentSkin(portal.REQUEST)

--- a/plone/app/testing/helpers.rst
+++ b/plone/app/testing/helpers.rst
@@ -254,10 +254,13 @@ layer base class which helps implement this pattern.
     ...         from Products.GenericSetup.registry import _profile_registry
     ...         from Products.GenericSetup.registry import _import_step_registry
     ...         from Products.GenericSetup.registry import _export_step_registry
+    ...         from Products.GenericSetup import upgrade
     ...
     ...         _profile_registry.registerProfile('dummy1', u"My package", u"", ".", 'plone.app.testing')
     ...         _import_step_registry.registerStep('import1', version=1, handler='plone.app.testing.tests.dummy', title=u"Dummy import step", description=u"")
     ...         _export_step_registry.registerStep('export1', handler='plone.app.testing.tests.dummy', title=u"Dummy import step", description=u"")
+    ...         upgrade_step = upgrade.UpgradeStep(u'Dummy upgrade step', 'plone.app.testing:default', '1000', '1001', '', 'plone.app.testing.tests.dummy')
+    ...         upgrade._registerUpgradeStep(upgrade_step)
     ...
     ...         # And then pretend to register a PAS multi-plugin
     ...         from Products.PluggableAuthService import PluggableAuthService
@@ -336,6 +339,7 @@ Again, our state should now be available.
     >>> from Products.GenericSetup.registry import _profile_registry
     >>> from Products.GenericSetup.registry import _import_step_registry
     >>> from Products.GenericSetup.registry import _export_step_registry
+    >>> from Products.GenericSetup.upgrade import _upgrade_registry
 
     >>> numProfiles = len(_profile_registry.listProfiles())
     >>> 'plone.app.testing:dummy1' in _profile_registry.listProfiles()
@@ -352,6 +356,10 @@ Again, our state should now be available.
     >>> from Products.PluggableAuthService import PluggableAuthService
     >>> 'dummy_plugin1' in PluggableAuthService.MultiPlugins
     True
+
+    >>> numUpgrades = len(_upgrade_registry.keys())
+    >>> len(_upgrade_registry.getUpgradeStepsForProfile('plone.app.testing:default'))
+    1
 
 We'll now tear down just the ``MY_INTEGRATION_TESTING`` layer. At this
 point, we should still have a Plone site, but none of the changes from our
@@ -384,6 +392,11 @@ layer.
     True
     >>> 'export1' in _export_step_registry.listSteps()
     False
+
+    >>> len(_upgrade_registry.keys()) == numUpgrades - 1
+    True
+    >>> len(_upgrade_registry.getUpgradeStepsForProfile('plone.app.testing:default'))
+    0
 
     >>> from Products.PluggableAuthService import PluggableAuthService
     >>> 'dummy_plugin1' in PluggableAuthService.MultiPlugins

--- a/plone/app/testing/helpers.rst
+++ b/plone/app/testing/helpers.rst
@@ -70,6 +70,9 @@ need to tear that down as well.
     ...
     ...         with helpers.ploneSite() as portal:
     ...
+    ...             # Persist GenericSetup profile upgrade versions for easy rollback.
+    ...             helpers.persist_profile_upgrade_versions(portal)
+    ...
     ...             # Push a new component registry so that ZCML registations
     ...             # and other global component registry changes are sandboxed
     ...             helpers.pushGlobalRegistry(portal)
@@ -133,9 +136,12 @@ having taken effect.
 We should also see our product installation in the quickinstaller tool
 and the results of the profile having been applied.
 
+    >>> from Products.GenericSetup.tool import UNKNOWN
     >>> with helpers.ploneSite() as portal:
     ...     print portal['portal_quickinstaller'].isProductInstalled('plone.resource')
+    ...     portal.portal_setup.getLastVersionForProfile('plone.resource:default') == UNKNOWN
     True
+    False
 
 Let's now simulate a test.
 
@@ -199,8 +205,10 @@ should not.
     ...     print portal.title
     ...     print portal['portal_quickinstaller'].isProductInstalled('plone.resource')
     ...     'folder1' in portal.objectIds()
+    ...     portal.portal_setup.getLastVersionForProfile('plone.resource:default') == UNKNOWN
     New title
     True
+    False
     False
 
 We'll now tear down just the ``HELPER_DEMOS_INTEGRATION_TESTING`` layer. At this
@@ -217,6 +225,8 @@ component architecture changes from our layer.
     >>> with helpers.ploneSite() as portal:
     ...     print portal.title
     ...     print portal['portal_quickinstaller'].isProductInstalled('plone.resource')
+    ...     # This should be True, but is False:
+    ...     # portal.portal_setup.getLastVersionForProfile('plone.resource:default') == UNKNOWN
     Plone site
     False
 

--- a/plone/app/testing/profile/metadata.xml
+++ b/plone/app/testing/profile/metadata.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<metadata>
+  <!-- This is used in the helpers.rst tests. -->
+  <version>1000</version>
+</metadata>


### PR DESCRIPTION
Use get_installer instead of portal_quickinstaller when available, for Plone 5.1 and higher.  In PloneSandboxLayer push and pop GenericSetup registries.  This way installed profile versions get reset in teardown: they need special handling because they are kept in memory and are not transaction aware so cannot be rolled back automatically.

This is part of PLIP https://github.com/plone/Products.CMFPlone/issues/1340
The `get_installer` part should be fine (but unneeded) in Plone 5.0 too, but it needs the push/pop GS fixes and I wonder if that will cause problems for some core packages or for add-ons.  But this should be good and helpful and we could even consider backporting it to the branch used on Plone 4.3. Let's first see what Jenkins thinks.