### PR TITLE
Load Products.CMFFormController in tests.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,9 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Load Products.CMFFormController in tests.  It is still used by core
+  Plone, also without Archetypes.  This makes the CMFFormController
+  tests pass.  [maurits]
 
 
 5.0.2 (2016-06-07)

--- a/plone/app/testing/layers.py
+++ b/plone/app/testing/layers.py
@@ -51,6 +51,7 @@ class PloneFixture(Layer):
         ('Products.PlonePAS',                    {'loadZCML': True}, ),
 
         ('Products.CMFQuickInstallerTool',       {'loadZCML': True}, ),
+        ('Products.CMFFormController',           {'loadZCML': True}, ),
         ('Products.CMFDynamicViewFTI',           {'loadZCML': True}, ),
         ('Products.CMFPlacefulWorkflow',         {'loadZCML': True}, ),
 


### PR DESCRIPTION
It is still used by core Plone, also without Archetypes.  This makes the CMFFormController tests pass. Otherwise they fail:

```
$ bin/test -s Products.CMFFormController
Running Testing.ZopeTestCase.layer.ZopeLite tests:
  Set up Testing.ZopeTestCase.layer.ZopeLite in 0.033 seconds.
  Running:
                
  Ran 5 tests with 0 failures, 0 errors, 0 skipped in 0.010 seconds.
Running plone.app.testing.bbb.PloneTestCase:Functional tests:
  Tear down Testing.ZopeTestCase.layer.ZopeLite in 0.000 seconds.
  Set up plone.testing.zca.LayerCleanup in 0.000 seconds.
  Set up plone.testing.z2.Startup in 0.116 seconds.
  Set up plone.app.testing.layers.PloneFixture in 6.562 seconds.
  Set up plone.app.testing.bbb.PloneTestCaseFixture in 1.139 seconds.
  Set up plone.app.testing.bbb.PloneTestCase:Functional in 0.000 seconds.
  Running:
    1/2 (50.0%) 

Error in test testCopy (Products.CMFFormController.tests.testCopyRename.TestCopyRename)
Traceback (most recent call last):
  File "/usr/local/pythons/parts/opt/lib/python2.7/unittest/case.py", line 329, in run
    testMethod()
  File "/Users/maurits/community/plone-coredev/5.0/src/Products.CMFFormController/Products/CMFFormController/tests/testCopyRename.py", line 56, in testCopy
    self.folder.manage_addProduct['CMFFormController'].manage_addControllerPageTemplate('test', 'Test', '<html>test</html>')
AttributeError: manage_addControllerPageTemplate

    2/2 (100.0%)

Error in test testRename (Products.CMFFormController.tests.testCopyRename.TestCopyRename)
Traceback (most recent call last):
  File "/usr/local/pythons/parts/opt/lib/python2.7/unittest/case.py", line 329, in run
    testMethod()
  File "/Users/maurits/community/plone-coredev/5.0/src/Products.CMFFormController/Products/CMFFormController/tests/testCopyRename.py", line 16, in testRename
    self.folder.manage_addProduct['CMFFormController'].manage_addControllerPageTemplate('test', 'Test', '<html>test</html>')
AttributeError: manage_addControllerPageTemplate


  Ran 2 tests with 0 failures, 2 errors, 0 skipped in 0.011 seconds.
Tearing down left over layers:
  Tear down plone.app.testing.bbb.PloneTestCase:Functional in 0.000 seconds.
  Tear down plone.app.testing.bbb.PloneTestCaseFixture in 0.006 seconds.
  Tear down plone.app.testing.layers.PloneFixture in 0.055 seconds.
  Tear down plone.testing.z2.Startup in 0.005 seconds.
  Tear down plone.testing.zca.LayerCleanup in 0.001 seconds.
Total: 7 tests, 0 failures, 2 errors, 0 skipped in 8.249 seconds.
```

Should be tested in combination with https://github.com/plone/buildout.coredev/pull/240, otherwise the CMFFormController tests are not run.