### PR TITLE
No longer try to load `Products.SecureMailHost` and its zcml.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- No longer try to load `Products.SecureMailHost` and its zcml.
+  This is not shipped with Plone 5.0 or higher.  [maurits]
 
 
 5.0.5 (2016-11-19)

--- a/plone/app/testing/layers.py
+++ b/plone/app/testing/layers.py
@@ -78,13 +78,6 @@ class PloneFixture(Layer):
     )
 
     try:
-        import Products.SecureMailHost  # noqa
-        products = products + (
-            ('Products.SecureMailHost', {'loadZCML': True}, ),)
-    except ImportError:
-        pass
-
-    try:
         import Products.PasswordResetTool  # noqa
         products = products + (
             ('Products.PasswordResetTool', {'loadZCML': True}, ),)


### PR DESCRIPTION
This is not shipped with Plone 5.0 or higher.
Depending on the import order in tests, there were two possibilities:

1. Products.SecureMailHost could not be imported.
2. Products.SecureMailHost was a fake module from Products.CMFPlone.patches.securemailhost.

In the first case, there was nothing for us to do.
In the second case, test setup completely failed, with:
`AttributeError: 'module' object has no attribute 'SecureMailHost'`

So: it is useless to still try to load this.

See also https://github.com/plone/Products.CMFPlone/pull/1777 and https://github.com/plone/Products.CMFPlone/issues/965