### PR TITLE
remove loading of SecureMailHost for plone4.3.x

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 4.2.6 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Do not load Products.SecureMailHost zcml.
+  It is not needed in Plone 4.  [frisi]
 
 
 4.2.5 (2015-03-17)

--- a/plone/app/testing/layers.py
+++ b/plone/app/testing/layers.py
@@ -65,7 +65,6 @@ class PloneFixture(Layer):
             ('Products.ExternalEditor'              , {'loadZCML': True}, ),
             ('Products.ExtendedPathIndex'           , {'loadZCML': True}, ),
             ('Products.ResourceRegistries'          , {'loadZCML': True}, ),
-            ('Products.SecureMailHost'              , {'loadZCML': True}, ),
 
             ('Products.PasswordResetTool'           , {'loadZCML': True}, ),
 


### PR DESCRIPTION
using a plone 4.3.12 buildout (of a bobtemplates.plone generated package) i get a warning during the layer setup when running tests
```
  Set up plone.testing.zca.LayerCleanup in 0.000 seconds.
  Set up plone.testing.z2.Startup in 0.372 seconds.
  Set up plone.app.testing.layers.PloneFixtureCould not install product Products.SecureMailHost
 in 11.935 seconds.
  Set up collective.contentrules.mustread.testing.CollectiveContentrulesMustreadLayer in 2.993 seconds.
  Set up collective.contentrules.mustread.testing.CollectiveContentrulesMustreadLayer:IntegrationTesting in 0.000 seconds.
  Running:
```

I got the following error when running a test that imports `from Products.CMFPlone.tests.utils import MockMailHost` (as suggested by https://docs.plone.org/develop/testing/unit_testing.html)

```
 Set up plone.testing.zca.LayerCleanup in 0.000 seconds.
  Set up plone.testing.z2.Startup in 0.261 seconds.
  Set up plone.app.testing.layers.PloneFixture Traceback (most recent call last):
  File "~/.buildout/eggs/zope.testing-3.9.7-py2.7.egg/zope/testing/testrunner/runner.py", line 366, in run_layer
    setup_layer(options, layer, setup_layers)
  File "~/.buildout/eggs/zope.testing-3.9.7-py2.7.egg/zope/testing/testrunner/runner.py", line 628, in setup_layer
    setup_layer(options, base, setup_layers)
  File "~/.buildout/eggs/zope.testing-3.9.7-py2.7.egg/zope/testing/testrunner/runner.py", line 628, in setup_layer
    setup_layer(options, base, setup_layers)
  File "~/.buildout/eggs/zope.testing-3.9.7-py2.7.egg/zope/testing/testrunner/runner.py", line 633, in setup_layer
    layer.setUp()
  File "~/.buildout/eggs/plone.app.testing-4.2.5-py2.7.egg/plone/app/testing/layers.py", line 104, in setUp
    self.setUpZCML()
  File "~/.buildout/eggs/plone.app.testing-4.2.5-py2.7.egg/plone/app/testing/layers.py", line 163, in setUpZCML
    loadAll('meta.zcml')
  File "~/.buildout/eggs/plone.app.testing-4.2.5-py2.7.egg/plone/app/testing/layers.py", line 155, in loadAll
    package = resolve(p)
  File "~/.buildout/eggs/zope.dottedname-3.4.6-py2.7.egg/zope/dottedname/resolve.py", line 39, in resolve
    found = getattr(found, n)
AttributeError: 'module' object has no attribute 'SecureMailHost'
```

i guess the correct solution for this is to backport https://github.com/plone/plone.app.testing/pull/38 to 4.2.x for plone 4.3 too.

if not, pleas let me know how to fix that best.