### PR TITLE
Remove backward compatibility for Products.PlacelessTranslationService

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,10 @@ Bug fixes:
 - *add item here*
 
 
+
+- Remove backward compatibility for Products.PlacelessTranslationService [ksuess]
+
+
 5.0.8 (2017-10-25)
 ------------------
 

--- a/plone/app/testing/layers.py
+++ b/plone/app/testing/layers.py
@@ -67,8 +67,6 @@ class PloneFixture(Layer):
         ('Products.CMFEditions',                 {'loadZCML': True}, ),
         ('Products.CMFDiffTool',                 {'loadZCML': True}, ),
 
-        ('Products.PlacelessTranslationService', {'loadZCML': True}, ),
-
         ('plonetheme.barceloneta',               {'loadZCML': True,
                                                   'install': False}, ),
 


### PR DESCRIPTION
Last thing  used from PTS was an adapter for IUserPreferredLanguages. It is replaced in zope.publisher.
Related pull requests: plone/plone.i18n#20 and https://github.com/plone/Products.CMFPlone/pull/2278