### PR TITLE
Install and load zcml of CMFQuickInstallerTool only when importable.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,9 @@ Breaking changes:
 
 New features:
 
+- Install and load zcml of CMFQuickInstallerTool only when importable.
+  [maurits]
+
 - Load negotiator from plone.i18n (PTS removed).
   [jensens, ksuess]
 

--- a/plone/app/testing/layers.py
+++ b/plone/app/testing/layers.py
@@ -51,7 +51,6 @@ class PloneFixture(Layer):
         ('Products.PluginRegistry',              {'loadZCML': True}, ),
         ('Products.PlonePAS',                    {'loadZCML': True}, ),
 
-        ('Products.CMFQuickInstallerTool',       {'loadZCML': True}, ),
         ('Products.CMFFormController',           {'loadZCML': True}, ),
         ('Products.CMFDynamicViewFTI',           {'loadZCML': True}, ),
         ('Products.CMFPlacefulWorkflow',         {'loadZCML': True}, ),
@@ -83,6 +82,12 @@ class PloneFixture(Layer):
         import Products.PasswordResetTool  # noqa
         products = products + (
             ('Products.PasswordResetTool', {'loadZCML': True}, ),)
+    except ImportError:
+        pass
+    try:
+        import Products.CMFQuickInstallerTool  # noqa
+        products = products + (
+            ('Products.CMFQuickInstallerTool', {'loadZCML': True}, ),)
     except ImportError:
         pass
 


### PR DESCRIPTION
It is on the way out.