### PR TITLE
Use dexterity instead of AT for PloneTestCase

### DIFF
--- a/src/plone/app/testing/bbb.py
+++ b/src/plone/app/testing/bbb.py
@@ -28,29 +28,18 @@ class PloneTestCaseFixture(testing.PloneSandboxLayer):
     defaultBases = (testing.PLONE_FIXTURE,)
 
     def setUpZope(self, app, configurationContext):
-        import Products.ATContentTypes
-        self.loadZCML(package=Products.ATContentTypes)
-
-        zope.installProduct(app, 'Products.Archetypes')
-        zope.installProduct(app, 'Products.ATContentTypes')
-        zope.installProduct(app, 'plone.app.blob')
-        zope.installProduct(app, 'plone.app.collection')
+        import plone.app.contenttypes
+        self.loadZCML(package=plone.app.contenttypes)
 
     def setUpPloneSite(self, portal):
         # restore default workflow
         testing.applyProfile(portal, 'Products.CMFPlone:testfixture')
 
         # add default content
-        testing.applyProfile(portal, 'Products.ATContentTypes:content')
+        testing.applyProfile(portal, 'plone.app.contenttypes:default')
 
         # add home folder for default test user
         _createMemberarea(portal, testing.TEST_USER_ID)
-
-    def tearDownZope(self, app):
-        zope.uninstallProduct(app, 'plone.app.collection')
-        zope.uninstallProduct(app, 'plone.app.blob')
-        zope.uninstallProduct(app, 'Products.ATContentTypes')
-        zope.uninstallProduct(app, 'Products.Archetypes')
 
 
 PTC_FIXTURE = PloneTestCaseFixture()

--- a/src/plone/app/testing/bbb.py
+++ b/src/plone/app/testing/bbb.py
@@ -36,7 +36,7 @@ class PloneTestCaseFixture(testing.PloneSandboxLayer):
         testing.applyProfile(portal, 'Products.CMFPlone:testfixture')
 
         # add default content
-        testing.applyProfile(portal, 'plone.app.contenttypes:default')
+        testing.applyProfile(portal, 'plone.app.contenttypes:plone-content')
 
         # add home folder for default test user
         _createMemberarea(portal, testing.TEST_USER_ID)


### PR DESCRIPTION
For now this is just a crazy experiment. Porting all tests away from PloneTestCase seems way more work that migrating the layer and fixing the tests. Also we have no replacement for self.publish in the modern testlayers.