### PR TITLE
add new bbb layer for Archetypes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,9 @@ New features:
 - Load negotiator from plone.i18n (PTS removed).
   [jensens, ksuess]
 
+- Add copy of bbb.PloneTestCase. For Plone 5.2 the bbb.PloneTestCase will uses Dexterity instead of Archetypes. Adding bbb_at.PloneTestCase for them to use allows to keep the AT tests working. See https://github.com/plone/plone.app.testing/pull/51
+  [pbauer]
+
 Bug fixes:
 
 - *add item here*

--- a/plone/app/testing/bbb_at.py
+++ b/plone/app/testing/bbb_at.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""Backwards-compatibility test class for PloneTestCase for Dexterity."""
+"""Backwards-compatibility test class for PloneTestCase for Archetypes."""
 
 from AccessControl import getSecurityManager
 from plone.app import testing


### PR DESCRIPTION
This is in preparation to changes in https://github.com/plone/plone.app.testing/pull/49. 

For Plone 5.2 the bbb.PloneTestCase will use Dexterity instead of Arcetypes which makes it much easier to fix all the failing tests in CMFPlone but also breaks most tests in Archetypes and related packages. This change allows to keep the AT tests working and allowing CMFPlone test to always use Dexterity even before https://github.com/plone/plone.app.testing/pull/49 is merged.

https://github.com/plone/Products.ATContentTypes/pull/56
https://github.com/plone/Products.Archetypes/pull/111
https://github.com/plone/Products.Marshall/pull/7
https://github.com/plone/Products.contentmigration/pull/19
https://github.com/plone/archetypes.schemaextender/pull/5
https://github.com/plone/plone.app.blob/pull/51
https://github.com/plone/plone.app.imaging/pull/36
https://github.com/plone/plone.app.folder/pull/19
https://github.com/plone/Products.CMFFormController/pull/16
