### PR TITLE
Fix now-false doctests on layer setup port selection.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Amended the doctests to work with automatical layer port picking from plone.testing.
+  [Rotonen]
 
 
 5.0.8 (2017-10-25)

--- a/plone/app/testing/layers.rst
+++ b/plone/app/testing/layers.rst
@@ -302,8 +302,7 @@ indicate where Zope is running.
 
     >>> port = layers.PLONE_ZSERVER['port']
     >>> import os
-    >>> port == int(os.environ.get('ZSERVER_PORT', 55001))
-    True
+    >>> # port == int(os.environ.get('ZSERVER_PORT', 0))
 
 Let's now simulate a test. Test setup does nothing beyond what the base layers
 do.
@@ -407,8 +406,7 @@ indicate where Zope is running.
 
     >>> port = layers.PLONE_FTP_SERVER['port']
     >>> import os
-    >>> port == int(os.environ.get('FTPSERVER_PORT', 55002))
-    True
+    >>> # port == int(os.environ.get('FTPSERVER_PORT', 0))
 
 Let's now simulate a test. Test setup does nothing beyond what the base layers
 do.


### PR DESCRIPTION
To be merged with the backport of plone.testing