### PR TITLE
Make plone.app.folder optional even in py2 

### DIFF
--- a/news/59.bugfix
+++ b/news/59.bugfix
@@ -1,0 +1,1 @@
+Make plone.app.folder a optional product for PloneFixture in py2

--- a/src/plone/app/testing/layers.py
+++ b/src/plone/app/testing/layers.py
@@ -69,8 +69,16 @@ class PloneFixture(Layer):
     if six.PY2:
         products += (
             ('Products.ExternalEditor', {'loadZCML': True}, ),
-            ('plone.app.folder', {'loadZCML': True}, ),
         )
+
+        try:
+            # Since gopipindex moved to plone.folder only with Archetypes
+            import plone.app.folder
+            products += (
+                ('plone.app.folder', {'loadZCML': True}, ),
+            )
+        except ImportError:
+            pass
 
     # try:
     #    import Products.PasswordResetTool


### PR DESCRIPTION
When you have no AT in py2 you do not have plone.app.folder as well. 

Fixes https://github.com/plone/Products.CMFPlone/issues/2753