### PR TITLE
[fix] Preserve ZCA site for transaction hooks that depend on it

### DIFF
--- a/src/plone/app/testing/helpers.py
+++ b/src/plone/app/testing/helpers.py
@@ -256,18 +256,19 @@ def ploneSite(db=None, connection=None, environ=None, flavour=zope):
     setHooks()
     site = getSite()
 
-    with getattr(flavour, 'zopeApp')(db, connection, environ) as app:
-        portal = app[PLONE_SITE_ID]
+    try:
+        with getattr(flavour, 'zopeApp')(db, connection, environ) as app:
+            portal = app[PLONE_SITE_ID]
 
-        setSite(portal)
-        login(portal, TEST_USER_NAME)
+            setSite(portal)
+            login(portal, TEST_USER_NAME)
 
-        try:
-            yield portal
-        finally:
-            logout()
-            if site is not portal:
-                setSite(site)
+            try:
+                yield portal
+            finally:
+                logout()
+    finally:
+        setSite(site)
 
 
 # Layer base class
@@ -379,7 +380,6 @@ class PloneSandboxLayer(Layer):
                 # Allow subclass to configure a persistent fixture
                 setSite(portal)
                 self.setUpPloneSite(portal)
-                setSite(None)
 
             # Keep track of PAS plugins that were added during setup
             self.snapshotMultiPlugins(preSetupMultiPlugins)


### PR DESCRIPTION
The `zope.component` site should not be cleared before committing transacions
in case any transaction hooks depend on it.

In the test in which I ran into this issue, the `transaction.commit()` failed
because the indexing queue was processing a
`plone.app.blocks.indexing.LayoutSearchableText` indexer at commit-time that
was trying to lookup a `plone.app.blocks.layoutbehavior.ILayoutAware` adapter.
Since that adapter depends on behavior-derived interfaces,
`plone.dexterity.schema` looks up a `plone.dexterity.interfaces.IDexterityFTI`
utility for the `portal_type` which fails if the site isn't set which in turn
yields no behavior interfaces which in turn makes the behavior-based adapter
lookup fail.

In my case, this wasn't even the symptom observed.  Because the commit failed
silently, the changes from applying the GS profile weren't persisted
including, in my case, a custom theme browser layer registration which in turn
meant a custom browser view lookup failed.  IOW, this silent commit failure
can lead to any number of very surprising, very wrong, and hard to diagnose
behaviors.

I'm not sure what changed or when, but this test worked under Python 2.7 and
Plone 5.1 and I'm fairly confident that nothing changed in the testing code on
"my" side that caused this and that the root change in behavior is somehow on
the Plone side of things.


----

#