### PR TITLE
Fixed test failure on Python 3 with Products.MailHost 4.10.

### DIFF
--- a/news/3178.bugfix
+++ b/news/3178.bugfix
@@ -1,0 +1,2 @@
+Fixed test failure on Python 3 with Products.MailHost 4.10.
+[maurits]

--- a/src/plone/app/testing/layers.rst
+++ b/src/plone/app/testing/layers.rst
@@ -440,7 +440,7 @@ If we send a message, we can check it in the list:
     ...     )
     >>> with helpers.ploneSite() as portal:
     ...     for message in portal.MailHost.messages:
-    ...         print(message)
+    ...         print(message.decode("utf-8"))
     MIME-Version: 1.0
     Content-Type: text/plain
     Subject: Test

--- a/tox.ini
+++ b/tox.ini
@@ -59,7 +59,7 @@ commands =
 skip_install = true
 
 deps =
-    isort
+    isort < 5
     flake8
     # helper to generate HTML reports:
     flake8-html
@@ -87,7 +87,7 @@ deps =
 commands =
     mkdir -p {toxinidir}/_build/reports/flake8
     - flake8 --format=html --htmldir={toxinidir}/_build/reports/flake8 --doctests src setup.py
-    flake8 --doctests src tests setup.py
+    flake8 --doctests src setup.py
     isort --check-only --recursive {toxinidir}/src
 
 whitelist_externals =


### PR DESCRIPTION
Message is now bytes instead of string.

Part of https://github.com/plone/Products.CMFPlone/issues/3178
Needs to be merged in combination with other PRs mentioned there.