### PR TITLE
Removed backwards compatibility code for old quickinstaller.

### DIFF
--- a/docs/README.rst
+++ b/docs/README.rst
@@ -505,11 +505,11 @@ Product and profile installation
                     ...
 
 ``quickInstallProduct(portal, productName, reinstall=False)``
-    Use this function to install a particular product into the given Plone
-    site, using the ``portal_quickinstaller`` tool. If ``reinstall`` is
-    ``False`` and the product is already installed, nothing will happen; if
-    ``reinstall`` is ``True``, the product will be reinstalled. The
-    ``productName`` should be a full dotted name, e.g. ``Products.MyProduct``,
+    Use this function to install a particular product into the given Plone site,
+    using the add-ons control panel code (portal setup).
+    If ``reinstall`` is ``False`` and the product is already installed, nothing will happen.
+    If ``reinstall`` is true, perform an uninstall and install if the product is installed already.
+    The ``productName`` should be a full dotted name, e.g. ``Products.MyProduct``,
     or ``my.product``.
 
     For example::
@@ -1143,13 +1143,13 @@ To apply a particular extension profile::
 This is the preferred method of installing a product's configuration.
 
 To install an add-on product into the Plone site using the
-``portal_quickinstaller`` tool::
+add-ons control panel::
 
     from plone.app.testing import quickInstallProduct
 
     quickInstallProduct(portal, 'my.product')
 
-To re-install a product using the quick-installer::
+To uninstall and install a product using the add-ons control panel::
 
     quickInstallProduct(portal, 'my.product', reinstall=True)
 
@@ -1164,10 +1164,10 @@ has been applied. Some of the more common such tests are shown below.
 To verify that a product has been installed (e.g. as a dependency via
 ``metadata.xml``)::
 
-    from Products.CMFCore.utils import getToolByName
+    from Products.CMFPlone.utils import get_installer
 
-    quickinstaller = getToolByName(portal, 'portal_quickinstaller')
-    self.assertTrue(quickinstaller.isProductInstalled('my.product'))
+    qi = get_installer(portal)
+    self.assertTrue(qi.is_product_installed('my.product'))
 
 To verify that a particular content type has been installed (e.g. via
 ``types.xml``)::

--- a/news/1775.feature
+++ b/news/1775.feature
@@ -1,0 +1,4 @@
+Removed backwards compatibility code for old quickinstaller.
+Current plone.app.testing is only for Plone 5.2+, so this code was no longer used.
+See also `PLIP 1775 <https://github.com/plone/Products.CMFPlone/issues/1775>`_.
+[maurits]

--- a/src/plone/app/testing/helpers.py
+++ b/src/plone/app/testing/helpers.py
@@ -68,9 +68,10 @@ def tearDownMultiPluginRegistration(pluginName):
 
 
 def quickInstallProduct(portal, productName, reinstall=False):
-    """Install a product using the ``portal_quickinstaller`` tool. If
-    ``reinstall`` is false and the product is already installed, do nothing.
-    If ``reinstall`` is true, perform an explicit reinstall if the product
+    """Install a product using the add-ons control panel (portal setup).
+
+    If ``reinstall`` is false and the product is already installed, do nothing.
+    If ``reinstall`` is true, perform an uninstall and install if the product
     is installed already.
     """
 
@@ -83,28 +84,16 @@ def quickInstallProduct(portal, productName, reinstall=False):
 
     zope.login(app['acl_users'], SITE_OWNER_NAME)
 
-    try:
-        from Products.CMFPlone.utils import get_installer
-    except ImportError:
-        # BBB For Plone 5.0 and lower.
-        qi = portal['portal_quickinstaller']
-        old_qi = True
-    else:
-        qi = get_installer(portal)
-        old_qi = False
+    from Products.CMFPlone.utils import get_installer
+
+    qi = get_installer(portal)
 
     try:
-        if old_qi:
-            if not qi.isProductInstalled(productName):
-                qi.installProduct(productName)
-            elif reinstall:
-                qi.reinstallProducts([productName])
-        else:
-            if not qi.is_product_installed(productName):
-                qi.install_product(productName, allow_hidden=True)
-            elif reinstall:
-                qi.uninstall_product(productName)
-                qi.install_product(productName, allow_hidden=True)
+        if not qi.is_product_installed(productName):
+            qi.install_product(productName, allow_hidden=True)
+        elif reinstall:
+            qi.uninstall_product(productName)
+            qi.install_product(productName, allow_hidden=True)
 
         portal.clearCurrentSkin()
         portal.setupCurrentSkin(portal.REQUEST)

--- a/src/plone/app/testing/helpers.rst
+++ b/src/plone/app/testing/helpers.rst
@@ -38,7 +38,7 @@ layer, we will perform the following setup:
 4. Make some persistent changes, to illustrate how these are torn down when
    we pop the ZODB ``DemoStorage``.
 
-5. Install a product using the ``get_installer`` view (or the old ``portal_quickinstaller`` tool).
+5. Install a product using the ``get_installer`` view.
 
 6. Apply a named extension profile.
 
@@ -50,15 +50,9 @@ course, if our setup had changed any other global or external state, we would
 need to tear that down as well.
 
     >>> def is_installed(portal, product_name):
-    ...     try:
-    ...         from Products.CMFPlone.utils import get_installer
-    ...     except ImportError:
-    ...         # BBB For Plone 5.0 and lower.
-    ...         qi = portal['portal_quickinstaller']
-    ...         return qi.isProductInstalled(product_name)
-    ...     else:
-    ...         qi = get_installer(portal)
-    ...         return qi.is_product_installed(product_name)
+    ...     from Products.CMFPlone.utils import get_installer
+    ...     qi = get_installer(portal)
+    ...     return qi.is_product_installed(product_name)
 
     >>> from plone.testing import Layer
     >>> from plone.testing import zca, zope, zodb
@@ -106,7 +100,7 @@ need to tear that down as well.
     ...             # Make some persistent changes
     ...             portal.title = u"New title"
     ...
-    ...             # Install a product using portal_quickinstaller
+    ...             # Install a product using the addons control panel
     ...             helpers.quickInstallProduct(portal, 'plone.app.testing')
     ...             assert is_installed(portal, 'plone.app.testing')
     ...
@@ -155,7 +149,7 @@ having taken effect.
     ...     print(portal.title)
     New title
 
-We should also see our product installation in the quickinstaller tool
+We should also see our product installation in the add-ons control panel
 and the results of the profile having been applied.
 
     >>> from Products.GenericSetup.tool import UNKNOWN

--- a/src/plone/app/testing/layers.py
+++ b/src/plone/app/testing/layers.py
@@ -81,19 +81,6 @@ class PloneFixture(Layer):
         except ImportError:
             pass
 
-    # try:
-    #    import Products.PasswordResetTool
-    #    products = products + (
-    #        ('Products.PasswordResetTool', {'loadZCML': True}, ),)
-    # except ImportError:
-    #    pass
-    # try:
-    #    import Products.CMFQuickInstallerTool
-    #    products = products + (
-    #        ('Products.CMFQuickInstallerTool', {'loadZCML': True}, ),)
-    # except ImportError:
-    #    pass
-
     # Extension profiles to be installed with site setup
     extensionProfiles = (
         'plonetheme.barceloneta:default',


### PR DESCRIPTION
Current plone.app.testing is only for Plone 5.2+, so this code was no longer used.
See also PLIP 1775: https://github.com/plone/Products.CMFPlone/issues/1775.

PLIP was approved.
I cherry-pick from the older branch from that PLIP.
This branch should work fine on 5.2 and 6.0 and can be tested and merged on its own.