### PR TITLE
Double check plone.app.folder

### DIFF
--- a/news/72.bugfix
+++ b/news/72.bugfix
@@ -1,0 +1,1 @@
+Before trying to load the zcml of plone.app.folder, double check if it is a real package or an alias provided by plone.app.upgrade

--- a/src/plone/app/testing/layers.py
+++ b/src/plone/app/testing/layers.py
@@ -75,9 +75,11 @@ class PloneFixture(Layer):
         try:
             # Since gopipindex moved to plone.folder only with Archetypes
             import plone.app.folder
-            products += (
-                ('plone.app.folder', {'loadZCML': True}, ),
-            )
+            # Prevent trying to load plone.app.folder if it is a module alias
+            if hasattr(plone.app.folder, "__file__"):
+                products += (
+                    ('plone.app.folder', {'loadZCML': True}, ),
+                )
         except ImportError:
             pass
 


### PR DESCRIPTION
Before trying to load the zcml of plone.app.folder, double check if it
is a real package or an alias provided by plone.app.upgrade

Fixes #72