### PR TITLE
Restore the previous admin password in tests

### DIFF
--- a/news/79.bugfix
+++ b/news/79.bugfix
@@ -1,0 +1,1 @@
+- Restore the previously used admin password for tests ("secret") [davisagli]

--- a/news/79.bugfix
+++ b/news/79.bugfix
@@ -1,1 +1,1 @@
-- Restore the previously used admin password for tests ("secret") [davisagli]
+Restore the previously used admin password for tests ("secret") [davisagli]

--- a/src/plone/app/testing/interfaces.py
+++ b/src/plone/app/testing/interfaces.py
@@ -12,6 +12,6 @@ TEST_USER_PASSWORD = 'correct horse battery staple'
 TEST_USER_ROLES = ['Member', ]
 
 SITE_OWNER_NAME = 'admin'
-SITE_OWNER_PASSWORD = 'correct horse battery staple'
+SITE_OWNER_PASSWORD = 'secret'
 
 ROBOT_TEST_LEVEL = 5


### PR DESCRIPTION
Let's see how much trouble it causes if we restore the old, shorter admin password in tests for backwards compatibility. See https://github.com/plone/plone.restapi/pull/1477 for more discussion. /cc @mauritsvanrees 