### PR TITLE
PloneFixture: explicitly install plone.app.contenttypes:default.

### DIFF
--- a/news/3961.feature
+++ b/news/3961.feature
@@ -1,0 +1,4 @@
+PloneFixture: explicitly install plone.app.contenttypes:default.
+The `addPloneSite` factory in Plone 6.1 no longer installs this by default.
+[maurits]
+

--- a/src/plone/app/testing/layers.py
+++ b/src/plone/app/testing/layers.py
@@ -70,7 +70,10 @@ class PloneFixture(Layer):
     )
 
     # Extension profiles to be installed with site setup
-    extensionProfiles = ("plonetheme.barceloneta:default",)
+    extensionProfiles = (
+        "plone.app.contenttypes:default",
+        "plonetheme.barceloneta:default",
+    )
 
     # Layer lifecycle
 


### PR DESCRIPTION
The `addPloneSite` factory in Plone 6.1 no longer installs this by default. See https://github.com/plone/Products.CMFPlone/issues/3961

Maybe we should only do this in Plone 6.1, together with https://github.com/plone/Products.CMFPlone/pull/3981.  But let's see if this is okay in 6.0 as well.  An issue could be that the contenttypes profile is then applied twice, which may take time, or very maybe break something.