### PR TITLE
Fix deprecation warnings.

### DIFF
--- a/docs/README.rst
+++ b/docs/README.rst
@@ -1164,7 +1164,7 @@ has been applied. Some of the more common such tests are shown below.
 To verify that a product has been installed (e.g. as a dependency via
 ``metadata.xml``)::
 
-    from Products.CMFPlone.utils import get_installer
+    from plone.base.utils import get_installer
 
     qi = get_installer(portal)
     self.assertTrue(qi.is_product_installed('my.product'))

--- a/news/+8571c2ca.bugfix.rst
+++ b/news/+8571c2ca.bugfix.rst
@@ -1,0 +1,3 @@
+Use ``plone.base.utils`` instead of ``Products.CMFPlone.utils`` when deprecated.
+No longer pass deprecated ``setup_content=False`` to ``addPloneSite`` call.
+[maurits]

--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,7 @@ setup(
         "Zope",
         "persistent",
         "plone.app.contenttypes",
+        "plone.base",
         "plone.dexterity",
         "plone.memoize",
         "plone.registry",

--- a/src/plone/app/testing/bbb.py
+++ b/src/plone/app/testing/bbb.py
@@ -2,8 +2,8 @@
 
 from AccessControl import getSecurityManager
 from plone.app import testing
+from plone.base.utils import unrestricted_construct_instance
 from plone.testing import zope
-from Products.CMFPlone.utils import _createObjectByType
 from Testing.ZopeTestCase.functional import Functional
 
 import transaction
@@ -14,7 +14,7 @@ def _createMemberarea(portal, user_id):
     mtool = portal.portal_membership
     members = mtool.getMembersFolder()
     if members is None:
-        _createObjectByType("Folder", portal, id="Members")
+        unrestricted_construct_instance("Folder", portal, id="Members")
     if not mtool.getMemberareaCreationFlag():
         mtool.setMemberareaCreationFlag()
     mtool.createMemberArea(user_id)

--- a/src/plone/app/testing/helpers.py
+++ b/src/plone/app/testing/helpers.py
@@ -79,7 +79,7 @@ def quickInstallProduct(portal, productName, reinstall=False):
 
     zope.login(app["acl_users"], SITE_OWNER_NAME)
 
-    from Products.CMFPlone.utils import get_installer
+    from plone.base.utils import get_installer
 
     qi = get_installer(portal)
 

--- a/src/plone/app/testing/helpers.rst
+++ b/src/plone/app/testing/helpers.rst
@@ -50,7 +50,7 @@ course, if our setup had changed any other global or external state, we would
 need to tear that down as well.
 
     >>> def is_installed(portal, product_name):
-    ...     from Products.CMFPlone.utils import get_installer
+    ...     from plone.base.utils import get_installer
     ...     qi = get_installer(portal)
     ...     return qi.is_product_installed(product_name)
 

--- a/src/plone/app/testing/layers.py
+++ b/src/plone/app/testing/layers.py
@@ -210,7 +210,6 @@ class PloneFixture(Layer):
             app,
             PLONE_SITE_ID,
             title=PLONE_SITE_TITLE,
-            setup_content=False,
             default_language=DEFAULT_LANGUAGE,
             extension_ids=self.extensionProfiles,
         )


### PR DESCRIPTION
Use `plone.base.utils` instead of `Products.CMFPlone.utils` when deprecated. No longer pass deprecated `setup_content=False` to `addPloneSite` call.

Sample warning for the last one:

```
Set up plone.app.testing.layers.PloneFixture
.../Products/CMFPlone/factory.py:176:
DeprecationWarning:
addPloneSite ignores the setup_content keyword argument since Plone 6.1,
treating it as always False. In Plone 7 it will be removed.
```
